### PR TITLE
CMake files cleanup, use QT_DBUS_LIB instead of Qt5DBus_FOUND

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,8 @@ cmake_minimum_required(VERSION 3.12)
 
 project(BitWave LANGUAGES C CXX)
 
-set(CMAKE_MODULE_PATH
+list(APPEND CMAKE_MODULE_PATH
         ${CMAKE_SOURCE_DIR}/cmake
-        ${CMAKE_MODULE_PATH}
         ${ECM_MODULE_PATH})
 
 include(cmake/ParseArguments.cmake)
@@ -15,28 +14,18 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 set(QT_MIN_VERSION 5.6.0)
 find_package(Qt5 ${QT_MIN_VERSION} REQUIRED COMPONENTS Core Gui Widgets Network Sql OpenGL Quick)
-if(HAVE_X11)
-    find_package(Qt5 ${QT_MIN_VERSION} REQUIRED COMPONENTS X11Extras)
-    find_package(Qt5DBus ${QT_MIN_VERSION})
-endif()
-if(APPLE)
-    find_package(Qt5 REQUIRED COMPONENTS MacExtras)
-endif()
-if(WIN32)
-    find_package(Qt5 REQUIRED COMPONENTS WinExtras)
-endif()
-
 set(QT_LIBRARIES Qt5::Core Qt5::Widgets Qt5::Network Qt5::Sql Qt5::OpenGL Qt5::Quick)
 
-if(Qt5DBus_FOUND)
-    set(QT_LIBRARIES ${QT_LIBRARIES} Qt5::DBus)
+if(APPLE)
+    find_package(Qt5 REQUIRED COMPONENTS MacExtras)
+    list(APPEND QT_LIBRARIES Qt5::MacExtras)
+elseif(WIN32)
+    find_package(Qt5 REQUIRED COMPONENTS WinExtras)
+    list(APPEND QT_LIBRARIES Qt5::WinExtras)
+else()
+    find_package(Qt5 REQUIRED COMPONENTS DBus)
+    list(APPEND QT_LIBRARIES Qt5::DBus)
     get_target_property(QT_DBUSXML2CPP_EXECUTABLE Qt5::qdbusxml2cpp LOCATION)
-endif()
-if(HAVE_X11)
-    set(QT_LIBRARIES ${QT_LIBRARIES} Qt5::X11Extras)
-endif()
-if(WIN32)
-    set(QT_LIBRARIES ${QT_LIBRARIES} Qt5::WinExtras)
 endif()
 
 find_package(MPV REQUIRED)
@@ -49,14 +38,6 @@ set(FFMPEG_LIBRARIES
         FFmpeg::avfilter)
 
 add_subdirectory(3rd/QtAES)
-
-if (NOT WIN32)
-    find_package(Qt5DBus REQUIRED)
-    set(QT_LIBRARIES ${QT_LIBRARIES} Qt5::DBus)
-    add_definitions(-DQt5DBus_FOUND)
-endif ()
-
-add_definitions(${QT_DEFINITIONS})
 
 set(QAPPLICATION_CLASS QApplication CACHE STRING "Inheritance class for SingleApplication")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,14 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
 
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
-set(CMAKE_MODULE_PATH
-        ${CMAKE_SOURCE_DIR}/cmake
-        ${CMAKE_MODULE_PATH}
-        ${ECM_MODULE_PATH})
-
-set(QAPPLICATION_CLASS QApplication CACHE STRING "Inheritance class for SingleApplication")
-
 qt5_add_resources(RESOURCES ./resources/main.qrc)
 
 set(MANAGERS_SRCS
@@ -99,7 +90,7 @@ set(SERVICES_SRCS
         services/base_service.h
         services/local_music_service.cpp
         services/local_music_service.h)
-        
+
 set(SRCS
         entry.cpp
         app_defs.cpp
@@ -115,7 +106,7 @@ set(SRCS
         ${RESOURCES})
 
 # DBUS and MPRIS - Unix specific
-if (UNIX AND Qt5DBus_FOUND)
+if (UNIX)
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/dbus)
     # message("DBUS FOUND")
     # MPRIS 2.0 DBUS interfaces
@@ -144,7 +135,7 @@ if (UNIX AND Qt5DBus_FOUND)
     qt5_add_dbus_interface(SRCS
             dbus/org.kde.kglobalaccel.Component.xml
             dbus/kglobalaccelcomponent)
-endif (UNIX AND Qt5DBus_FOUND)
+endif (UNIX)
 
 optional_source(Qt5DBus_FOUND
         SRCS

--- a/src/managers/app_manager.cpp
+++ b/src/managers/app_manager.cpp
@@ -24,6 +24,7 @@
 #include "lyric_provider_manager.h"
 #include "parser_manager.h"
 #include "player_manager.h"
+#include "queue_manager.h"
 
 void detectPaths();
 

--- a/src/managers/app_manager.cpp
+++ b/src/managers/app_manager.cpp
@@ -13,7 +13,7 @@
 #include <QStandardPaths>
 #include <QThread>
 
-#ifdef Qt5DBus_FOUND
+#ifdef QT_DBUS_LIB
 
 #include "dbus/mpris2.h"
 
@@ -45,7 +45,7 @@ void AppManager::initialize(const QString &file) {
     LyricProviderManager::instance()->moveToThread(mLyricProviderThread);
     mLyricProviderThread->start();
 
-#ifdef Qt5DBus_FOUND
+#ifdef QT_DBUS_LIB
     using mpris::Mpris2;
     new Mpris2(this);
 //    qDebug() << "MPRIS2 loaded.";


### PR DESCRIPTION
- Changed some `set(LIST LIST MoreItem)` to `list(APPEND LIST MoreItem)`
- Removed unused variable `HAVE_X11`
- Changed macro from `Qt5DBus_FOUND` to Qt's `QT_DBUS_LIB`