### PR TITLE
Fix parser and decoder

### DIFF
--- a/src/codec/mpv_codec.cc
+++ b/src/codec/mpv_codec.cc
@@ -18,5 +18,5 @@ const QStringList& MpvCodec::supportedFormats() { return m_supportedFormats; }
 
 bool MpvCodec::accepted(const Media& src) {
     auto fileInfo = QFileInfo(src.url());
-    return m_supportedFormats.contains(fileInfo.suffix());
+    return m_supportedFormats.contains(fileInfo.suffix().toLower());
 }

--- a/src/codec/ncm_codec.cc
+++ b/src/codec/ncm_codec.cc
@@ -20,7 +20,7 @@ const QStringList& NcmCodec::supportedFormats() { return m_supportedFormats; }
 
 bool NcmCodec::accepted(const Media& src) {
     auto fileInfo = QFileInfo(src.url());
-    return m_supportedFormats.contains(fileInfo.suffix());
+    return m_supportedFormats.contains(fileInfo.suffix().toLower());
 }
 
 QString NcmCodec::decode(const Media& src) {

--- a/src/library/library.cc
+++ b/src/library/library.cc
@@ -121,7 +121,7 @@ void Library::scan() {
         for (auto& media : mediaNew) {
             if (media.type() == MUSIC) {
                 m_musics.append(media);
-            } else {
+            } else if (media.type() == VIDEO) {
                 m_videos.append(media);
             }
             Storage::instance()->addMedia(media);

--- a/src/parser/ffmpeg_parser.cc
+++ b/src/parser/ffmpeg_parser.cc
@@ -64,7 +64,7 @@ Media FfmpegParser::parse(const QString& path) {
 
     // detect file type by iterate ffmpeg streams
     auto fileInfo = QFileInfo(path);
-    auto suffix = fileInfo.suffix();
+    auto suffix = fileInfo.suffix().toLower();
     if (m_supportedVideoFormats.contains(suffix))
         media.setType(VIDEO);
     else if (m_supportedAudioFormats.contains(suffix))


### PR DESCRIPTION
### PR Description:
This PR fixes an issue in the parser and decoder that caused media files with uppercase extensions (e.g., `.MP3`) to be incorrectly categorized and unplayable.

### Steps to Reproduce:
1. Place a media file with a supported format (e.g., `.mp3`) in the appropriate location, then modify its extension to uppercase (e.g., `.MP3`).
2. Launch **BitWave** and click the `Scan Media` button in **LibraryView**.
3. The file appears in the **VideoList** instead of the **MusicList** and cannot be played correctly.

### Fix Summary:
- Adjusted the parser and decoder logic to ensure that file extensions are matched case-insensitively, preventing misclassification and ensuring proper playback.